### PR TITLE
Always pull image

### DIFF
--- a/sso-12-52-01-ga-base.json
+++ b/sso-12-52-01-ga-base.json
@@ -212,6 +212,7 @@
                   }
                 ],
                 "image": "store.vapp-security.solutions/ssignon/policy-server:12.52.01.ga",
+                "imagePullPolicy": "Always",
                 "name": "policy-server",
                 "ports": [
                   {


### PR DESCRIPTION
If the image tag is `latest` it is always pulled, but to check the image every time for other tags,  `"imagePullPolicy": "Always"` must be used.